### PR TITLE
Added a flag that controls if zfs will NFS export a newly created persistent volume claim.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,298 +3,631 @@
 
 [[projects]]
   branch = "default"
+  digest = "1:db5c4e7a9516334fb1e9d5951fb9943d0f13e4f415a77c22b97e60f4d10a62a7"
   name = "bitbucket.org/ww/goautoneg"
   packages = ["."]
+  pruneopts = ""
   revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 
 [[projects]]
+  digest = "1:7020b5857474f4cd4ac3326eb0fc8bcf2a639ed0a732b42dce9083afea1e2e54"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
+  pruneopts = ""
   revision = "8a290539e2e8629dbc4e6bad948158f790ec31f4"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:eefdb56f035de98e76cc8b7d154faf3ac0aa1db212f789cf17454775249c8254"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
+  pruneopts = ""
   revision = "5bd2802263f21d8788851d5305584c82a5c75d7e"
 
 [[projects]]
+  digest = "1:b9585eba46f28b2dbdb61168d95d34d7646825ceb0111666c0326a835a59b6f2"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "ba1b36c82c5e05c4f912a88eab0dcd91a171688f"
   version = "v0.11.5"
 
 [[projects]]
+  digest = "1:9f3e434359a70c2e5d2f31e1cf558174fd089d10117dd51977a752faff8c348e"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "b965b613227fddccbfffe13eae360ed3fa822f8d"
 
 [[projects]]
+  digest = "1:3734a927c8a61903115e561a1a7860153e5c02b4f80f21b13467a42759f04ac5"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 
 [[projects]]
+  digest = "1:389a45ab4fb51613b8ac2af112ce38d024c51194b557d953b986637176aa877e"
   name = "github.com/docker/distribution"
-  packages = ["digest","reference"]
+  packages = [
+    "digest",
+    "reference",
+  ]
+  pruneopts = ""
   revision = "cd27f179f2c10c5d300e6d09025b538c475b0d51"
 
 [[projects]]
+  digest = "1:3430d6e8e620d37a9e9793802af785b9c3359d6a516d7064503a831fd5f638fb"
   name = "github.com/emicklei/go-restful"
-  packages = [".","log","swagger"]
+  packages = [
+    ".",
+    "log",
+    "swagger",
+  ]
+  pruneopts = ""
   revision = "09691a3b6378b740595c1002f40c34dd5f218a22"
 
 [[projects]]
+  digest = "1:e681480857cc3b0db8ada87cf70590550d4e85a77041926effeb23797223eb3d"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = ""
   revision = "bd2828f9f176e52d7222e565abb2d338d3f3c103"
 
 [[projects]]
+  branch = "master"
+  digest = "1:c43f000fdc7dd5d2a5d114624f9b33cda02f72b878c5e1e3d27299c27d4405c7"
+  name = "github.com/gentics/kubernetes-zfs-provisioner"
+  packages = ["pkg/provisioner"]
+  pruneopts = ""
+  revision = "280ab7e7744cea57c3ee3be967e0a3651b0b1678"
+
+[[projects]]
+  digest = "1:a31fbb19d2b38d50bc125d97b7c3e7a286d3f6f37d18756011eb6e7d1a9fa7d0"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = ""
   revision = "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
 
 [[projects]]
+  digest = "1:d5684de69d41b91bbc4582447389b6e3d422a856c7863e2cb69e83fa22585686"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
+  pruneopts = ""
   revision = "46af16f9f7b149af66e5d1bd010e3574dc06de98"
 
 [[projects]]
+  digest = "1:880132ce271710075e3dd41e5b267fb444feb4d3f6a2a6031227af8cadfa4ad0"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
+  pruneopts = ""
   revision = "13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272"
 
 [[projects]]
+  digest = "1:2d7624c60176d2eefb4d5029163002282de792172273cd965d8d3ce2dfcd1ccf"
   name = "github.com/go-openapi/spec"
   packages = ["."]
+  pruneopts = ""
   revision = "6aced65f8501fe1217321abf0749d354824ba2ff"
 
 [[projects]]
+  digest = "1:60a4d50770b16e62199e9acad6bc92b6835d93538545933d48fc7adf0f4d8edb"
   name = "github.com/go-openapi/swag"
   packages = ["."]
+  pruneopts = ""
   revision = "1d0bd113de87027671077d3c71eb3ac5d7dbba72"
 
 [[projects]]
+  digest = "1:ffb5b7428f6b19409284b9b6907878190189c14e48b4e83aaa591e3a921d6429"
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
+  packages = [
+    "proto",
+    "sortkeys",
+  ]
+  pruneopts = ""
   revision = "e18d7aa8f8c624c915db340349aad4c49b10d173"
 
 [[projects]]
+  digest = "1:ed314700d20eeaaa904b47e6fd3d4866f7bd14887a4904a9f69ec1e47385416f"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = ""
   revision = "44145f04b68cf362d9c4df2182967c2275eaefed"
 
 [[projects]]
+  digest = "1:515a069bab37826c425e12345063ae6a0cc711121819e1eeaab1da4052d72dbf"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
+  pruneopts = ""
   revision = "02826c3e79038b59d737d3b1c0a1d937f71a4433"
 
 [[projects]]
+  digest = "1:617ff1d7c2ba3ba08f0c4cde79ff569324e972c3dbba3d42ed07f9649595c520"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "8616e8ee5e20a1704615e6c8d7afcdac06087a67"
 
 [[projects]]
+  digest = "1:a2823c34933d4a2b36284f617f483d51fe156a443923284b3660f183dcfa3338"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = ""
   revision = "44d81051d367757e1c7c6a5a86423ece9afcf63c"
 
 [[projects]]
+  digest = "1:a4684067c99516927192da7fece2190f2ec1aebc5709d89392f910ae3921d18c"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = ""
   revision = "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1"
 
 [[projects]]
+  digest = "1:57925cae2350c91dadfadf9d4e28bc076c9be5ffd87213db314805a8d38aba26"
   name = "github.com/howeyc/gopass"
   packages = ["."]
+  pruneopts = ""
   revision = "3ca23474a7c7203e0a0a070fd33508f6efdb9b3d"
 
 [[projects]]
+  digest = "1:af7e132906cb360f4d7c34a9e1434825467f21c4ff5c521ad4cc5b55352876a8"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = ""
   revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"
 
 [[projects]]
+  digest = "1:2b282bd76718cf2443ea6c5143d0915840ed15417c970619f7e08674de5f4eea"
   name = "github.com/juju/ratelimit"
   packages = ["."]
+  pruneopts = ""
   revision = "77ed1c8a01217656d2080ad51981f6e99adaa177"
 
 [[projects]]
   branch = "master"
+  digest = "1:abde445510ed7b23086372c0bfdb607091e8118ca94ee853153a2d7709d65087"
   name = "github.com/kr/fs"
   packages = ["."]
+  pruneopts = ""
   revision = "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
 
 [[projects]]
+  digest = "1:d73babf15d484ad1ea56c8402df06ca68d4a3ade03f845701a86a86edfab7ad1"
   name = "github.com/kubernetes-incubator/external-storage"
-  packages = ["lib/controller","lib/leaderelection","lib/leaderelection/resourcelock"]
+  packages = [
+    "lib/controller",
+    "lib/leaderelection",
+    "lib/leaderelection/resourcelock",
+  ]
+  pruneopts = ""
   revision = "11dd9d7b2915b8c39147db492fe9d00562955318"
   version = "v2.1.0"
 
 [[projects]]
+  digest = "1:f2dfc1a0b89affe26feaff956a955aef5b13fb58ad3dd82fb773bf0afa940a92"
   name = "github.com/magiconair/properties"
   packages = ["."]
+  pruneopts = ""
   revision = "0723e352fa358f9322c938cc2dadda874e9151a9"
 
 [[projects]]
+  digest = "1:5f3c38b5f2dd7bec9286e00c3ac7babbe68859cc0edc4d3e3ba3fda93c24d7e7"
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter",
+  ]
+  pruneopts = ""
   revision = "d5b7844b561a7bc640052f1b935f7b800330d7e0"
 
 [[projects]]
+  digest = "1:5cede773920242d962f02e2adc7596b23f7acc5f8ea93714a3f8a934579ffaa1"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
 
 [[projects]]
+  digest = "1:a8f808f13da8f202c83ab5e754fb644cae251f24c90a67b36dfcc67d165f9005"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "db1efb556f84b25a0a13a04aad883943538ad2e0"
 
 [[projects]]
+  digest = "1:3e6edf30061fbdbb55f0e99a78891cad4c4cb0307bdbb42f5f02813c431c2fcc"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "ca53cad383cad2479bbba7f7a1a05797ec1386e4"
 
 [[projects]]
+  digest = "1:4695c53c1975d06fdfc3e72b900d7cce9c7b8a402d32e636d142090a5285af4d"
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
+  pruneopts = ""
   revision = "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:d36e8abec0c59acac37eb3ad8fa7e96c0983bd808a30a45e5d77e517f92f5608"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = ""
   revision = "45932ad32dfdd20826f5671da37a5f3ce9f26a8d"
 
 [[projects]]
+  digest = "1:9a88d02723adf65f195ffec4bb458024113027188015555f30e2743d9f006b11"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "a22138067af1c4942683050411a841ade67fe1eb"
 
 [[projects]]
+  digest = "1:15dea2b42d9b823f300e3fcdddb00dc60ddd5556f511eb4adc415d94c4335d38"
   name = "github.com/pkg/sftp"
   packages = ["."]
+  pruneopts = ""
   revision = "4d0e916071f68db74f8a73926335f809396d6b42"
 
 [[projects]]
+  digest = "1:31ba63a60f9e41b5cbb6cce48f4756718bd514fe73a1c6ee2751ec8fbf6e109f"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
 
 [[projects]]
+  digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = ""
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:d20fc05e7dfd1cf72429188a04109e12937ff582b9f9e3a700b2665349b7ca95"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
 
 [[projects]]
+  digest = "1:36bc45062264b0b716f9eff11a9d07328ed9e2cf2a97e9f7473641733e6294a1"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","model"]
+  packages = [
+    "expfmt",
+    "model",
+  ]
+  pruneopts = ""
   revision = "ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650"
 
 [[projects]]
+  digest = "1:396f7d7a0e23f62df4dbcda921c74a74e7d25b2fea7e81759fc58d5967d514df"
   name = "github.com/prometheus/procfs"
   packages = ["."]
+  pruneopts = ""
   revision = "fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60"
 
 [[projects]]
   branch = "master"
+  digest = "1:daf7ece9411f44f7a6f1ef6ee7e8f8e3a5fa45c3f75d1c631210790537ba24c7"
   name = "github.com/simt2/go-zfs"
   packages = ["."]
+  pruneopts = ""
   revision = "1716e0f6768bfdedb714a35e56b78c479d8080fa"
 
 [[projects]]
+  digest = "1:a3b50b16dd7ab896dfc78d739e8aa1da415768424d111bcdbca14aef8cb3f04c"
   name = "github.com/spf13/afero"
-  packages = [".","mem","sftp"]
+  packages = [
+    ".",
+    "mem",
+    "sftp",
+  ]
+  pruneopts = ""
   revision = "b28a7effac979219c2a2ed6205a4d70e4b1bcd02"
 
 [[projects]]
+  digest = "1:e1daa2c9d617f8e63d9c28820a4b48546430549ff4540f57e3415789259f2316"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = ""
   revision = "2580bc98dc0e62908119e4737030cc2fdfc45e4c"
 
 [[projects]]
+  digest = "1:f0116a3f4f5b36e3917f7758c67a80488606288f87e716e88f11b845200cc003"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
+  pruneopts = ""
   revision = "33c24e77fb80341fe7130ee7c594256ff08ccc46"
 
 [[projects]]
+  digest = "1:3d93c7c561ca745667a66a9d85654d8d5f87bdbbcf71e85a8996d3210d9dafde"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "dabebe21bf790f782ea4c7bbd2efc430de182afd"
 
 [[projects]]
+  digest = "1:e7b08983bb661c7d7c6b1ea5cf026b1ff373d6cffb8a40dd9b57aa8fc7468a9f"
   name = "github.com/spf13/viper"
   packages = ["."]
+  pruneopts = ""
   revision = "50515b700e02658272117a72bd641b6b7f1222e5"
 
 [[projects]]
+  digest = "1:3926a4ec9a4ff1a072458451aa2d9b98acd059a45b38f7335d31e06c3d6a0159"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = ""
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [[projects]]
+  digest = "1:cb2800cd5716e9d6172888e0e3ffe1f9c07b7f142eb83d49a391029bcf4f6cc1"
   name = "github.com/ugorji/go"
   packages = ["codec"]
+  pruneopts = ""
   revision = "ded73eae5db7e7a0ef6f55aace87a2873c5d2b74"
 
 [[projects]]
+  digest = "1:0f67b4bbcdf1caaee0450f225a53fd2c2f8793578cc7810eb09c290e008e33ac"
   name = "golang.org/x/crypto"
-  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/terminal"]
+  packages = [
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "ssh",
+    "ssh/terminal",
+  ]
+  pruneopts = ""
   revision = "d172538b2cfce0c13cee31e647d0367aa8cd2486"
 
 [[projects]]
+  digest = "1:8d5d4c9d4b35fe2abfc82ec0bb371d50ac9aef414f09ad756f5dff54dd81df94"
   name = "golang.org/x/net"
-  packages = ["http2","http2/hpack","idna","lex/httplex"]
+  packages = [
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex",
+  ]
+  pruneopts = ""
   revision = "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
 
 [[projects]]
+  digest = "1:b6e4bf8197b5de25f2ed05c603d39d619f4c41bb4a573ef5274c3446df44d6e4"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9"
 
 [[projects]]
+  digest = "1:9fa38bfa647dffc304504ea076b54f7eeb28f7ff7476536695abffcc1addd6d1"
   name = "golang.org/x/text"
-  packages = ["cases","internal/gen","internal/tag","internal/triegen","internal/ucd","language","runes","secure/bidirule","secure/precis","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "cases",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "runes",
+    "secure/bidirule",
+    "secure/precis",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width",
+  ]
+  pruneopts = ""
   revision = "2910a502d2bf9e43193af9d68ca516529614eed3"
 
 [[projects]]
+  digest = "1:e5d1fb981765b6f7513f793a3fcaac7158408cca77f75f7311ac82cc88e9c445"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = ""
   revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
   version = "v0.9.0"
 
 [[projects]]
+  digest = "1:0763e9b61d1ce4cc56451110312698daadb7273385c7425c746f06ae7d68e3f3"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "a5b47d31c556af34a302ce5d659e6fea44d90de0"
 
 [[projects]]
+  digest = "1:772a730aa78a94b302c43f6a86f7178838bff8c4a225328de3743d66a4e56cc9"
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apimachinery","pkg/apimachinery/announced","pkg/apimachinery/registered","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/openapi","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/mergepatch","pkg/util/net","pkg/util/rand","pkg/util/runtime","pkg/util/sets","pkg/util/strategicpatch","pkg/util/uuid","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/json","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apimachinery",
+    "pkg/apimachinery/announced",
+    "pkg/apimachinery/registered",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/openapi",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/diff",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/mergepatch",
+    "pkg/util/net",
+    "pkg/util/rand",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/strategicpatch",
+    "pkg/util/uuid",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/json",
+    "third_party/forked/golang/reflect",
+  ]
+  pruneopts = ""
   revision = "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
 
 [[projects]]
+  digest = "1:ddaf109a69f97a91d93108434136fc6e30603ece0e49d6d22aae6befbe2632e3"
   name = "k8s.io/client-go"
-  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/apps/v1beta1","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/api","pkg/api/install","pkg/api/v1","pkg/apis/apps","pkg/apis/apps/install","pkg/apis/apps/v1beta1","pkg/apis/authentication","pkg/apis/authentication/install","pkg/apis/authentication/v1","pkg/apis/authentication/v1beta1","pkg/apis/authorization","pkg/apis/authorization/install","pkg/apis/authorization/v1","pkg/apis/authorization/v1beta1","pkg/apis/autoscaling","pkg/apis/autoscaling/install","pkg/apis/autoscaling/v1","pkg/apis/autoscaling/v2alpha1","pkg/apis/batch","pkg/apis/batch/install","pkg/apis/batch/v1","pkg/apis/batch/v2alpha1","pkg/apis/certificates","pkg/apis/certificates/install","pkg/apis/certificates/v1beta1","pkg/apis/extensions","pkg/apis/extensions/install","pkg/apis/extensions/v1beta1","pkg/apis/policy","pkg/apis/policy/install","pkg/apis/policy/v1beta1","pkg/apis/rbac","pkg/apis/rbac/install","pkg/apis/rbac/v1alpha1","pkg/apis/rbac/v1beta1","pkg/apis/settings","pkg/apis/settings/install","pkg/apis/settings/v1alpha1","pkg/apis/storage","pkg/apis/storage/install","pkg/apis/storage/v1","pkg/apis/storage/v1beta1","pkg/util","pkg/util/parsers","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/record","transport","util/cert","util/clock","util/flowcontrol","util/homedir","util/integer"]
+  packages = [
+    "discovery",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2alpha1",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1beta1",
+    "pkg/api",
+    "pkg/api/install",
+    "pkg/api/v1",
+    "pkg/apis/apps",
+    "pkg/apis/apps/install",
+    "pkg/apis/apps/v1beta1",
+    "pkg/apis/authentication",
+    "pkg/apis/authentication/install",
+    "pkg/apis/authentication/v1",
+    "pkg/apis/authentication/v1beta1",
+    "pkg/apis/authorization",
+    "pkg/apis/authorization/install",
+    "pkg/apis/authorization/v1",
+    "pkg/apis/authorization/v1beta1",
+    "pkg/apis/autoscaling",
+    "pkg/apis/autoscaling/install",
+    "pkg/apis/autoscaling/v1",
+    "pkg/apis/autoscaling/v2alpha1",
+    "pkg/apis/batch",
+    "pkg/apis/batch/install",
+    "pkg/apis/batch/v1",
+    "pkg/apis/batch/v2alpha1",
+    "pkg/apis/certificates",
+    "pkg/apis/certificates/install",
+    "pkg/apis/certificates/v1beta1",
+    "pkg/apis/extensions",
+    "pkg/apis/extensions/install",
+    "pkg/apis/extensions/v1beta1",
+    "pkg/apis/policy",
+    "pkg/apis/policy/install",
+    "pkg/apis/policy/v1beta1",
+    "pkg/apis/rbac",
+    "pkg/apis/rbac/install",
+    "pkg/apis/rbac/v1alpha1",
+    "pkg/apis/rbac/v1beta1",
+    "pkg/apis/settings",
+    "pkg/apis/settings/install",
+    "pkg/apis/settings/v1alpha1",
+    "pkg/apis/storage",
+    "pkg/apis/storage/install",
+    "pkg/apis/storage/v1",
+    "pkg/apis/storage/v1beta1",
+    "pkg/util",
+    "pkg/util/parsers",
+    "pkg/version",
+    "rest",
+    "rest/watch",
+    "tools/auth",
+    "tools/cache",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/record",
+    "transport",
+    "util/cert",
+    "util/clock",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer",
+  ]
+  pruneopts = ""
   revision = "76153773eaa3a268131d3d993290a194a1370585"
 
 [[projects]]
+  digest = "1:19b9e843c2efa09c7b7b3ba535ae843bd7b5f8e52a75d6a914798df1f8d19782"
   name = "k8s.io/kubernetes"
-  packages = ["pkg/util/goroutinemap","pkg/util/goroutinemap/exponentialbackoff","pkg/util/version"]
+  packages = [
+    "pkg/util/goroutinemap",
+    "pkg/util/goroutinemap/exponentialbackoff",
+    "pkg/util/version",
+  ]
+  pruneopts = ""
   revision = "fff5156092b56e6bd60fff75aad4dc9de6b6ef37"
   version = "v1.6.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8c89b6ca01f41542de5cf533925ef76ca35d7d4c16b78765b57e08c8ffa9a1a0"
+  input-imports = [
+    "github.com/Sirupsen/logrus",
+    "github.com/gentics/kubernetes-zfs-provisioner/pkg/provisioner",
+    "github.com/kubernetes-incubator/external-storage/lib/controller",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/simt2/go-zfs",
+    "github.com/spf13/viper",
+    "github.com/stretchr/testify/assert",
+    "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/util/validation",
+    "k8s.io/apimachinery/pkg/util/validation/field",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/pkg/api/v1",
+    "k8s.io/client-go/tools/clientcmd",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,631 +3,298 @@
 
 [[projects]]
   branch = "default"
-  digest = "1:db5c4e7a9516334fb1e9d5951fb9943d0f13e4f415a77c22b97e60f4d10a62a7"
   name = "bitbucket.org/ww/goautoneg"
   packages = ["."]
-  pruneopts = ""
   revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 
 [[projects]]
-  digest = "1:7020b5857474f4cd4ac3326eb0fc8bcf2a639ed0a732b42dce9083afea1e2e54"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
-  pruneopts = ""
   revision = "8a290539e2e8629dbc4e6bad948158f790ec31f4"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:eefdb56f035de98e76cc8b7d154faf3ac0aa1db212f789cf17454775249c8254"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
-  pruneopts = ""
   revision = "5bd2802263f21d8788851d5305584c82a5c75d7e"
 
 [[projects]]
-  digest = "1:b9585eba46f28b2dbdb61168d95d34d7646825ceb0111666c0326a835a59b6f2"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
-  pruneopts = ""
   revision = "ba1b36c82c5e05c4f912a88eab0dcd91a171688f"
   version = "v0.11.5"
 
 [[projects]]
-  digest = "1:9f3e434359a70c2e5d2f31e1cf558174fd089d10117dd51977a752faff8c348e"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  pruneopts = ""
   revision = "b965b613227fddccbfffe13eae360ed3fa822f8d"
 
 [[projects]]
-  digest = "1:3734a927c8a61903115e561a1a7860153e5c02b4f80f21b13467a42759f04ac5"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = ""
   revision = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 
 [[projects]]
-  digest = "1:389a45ab4fb51613b8ac2af112ce38d024c51194b557d953b986637176aa877e"
   name = "github.com/docker/distribution"
-  packages = [
-    "digest",
-    "reference",
-  ]
-  pruneopts = ""
+  packages = ["digest","reference"]
   revision = "cd27f179f2c10c5d300e6d09025b538c475b0d51"
 
 [[projects]]
-  digest = "1:3430d6e8e620d37a9e9793802af785b9c3359d6a516d7064503a831fd5f638fb"
   name = "github.com/emicklei/go-restful"
-  packages = [
-    ".",
-    "log",
-    "swagger",
-  ]
-  pruneopts = ""
+  packages = [".","log","swagger"]
   revision = "09691a3b6378b740595c1002f40c34dd5f218a22"
 
 [[projects]]
-  digest = "1:e681480857cc3b0db8ada87cf70590550d4e85a77041926effeb23797223eb3d"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
-  pruneopts = ""
   revision = "bd2828f9f176e52d7222e565abb2d338d3f3c103"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c43f000fdc7dd5d2a5d114624f9b33cda02f72b878c5e1e3d27299c27d4405c7"
-  name = "github.com/gentics/kubernetes-zfs-provisioner"
-  packages = ["pkg/provisioner"]
-  pruneopts = ""
-  revision = "280ab7e7744cea57c3ee3be967e0a3651b0b1678"
-
-[[projects]]
-  digest = "1:a31fbb19d2b38d50bc125d97b7c3e7a286d3f6f37d18756011eb6e7d1a9fa7d0"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = ""
   revision = "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
 
 [[projects]]
-  digest = "1:d5684de69d41b91bbc4582447389b6e3d422a856c7863e2cb69e83fa22585686"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
-  pruneopts = ""
   revision = "46af16f9f7b149af66e5d1bd010e3574dc06de98"
 
 [[projects]]
-  digest = "1:880132ce271710075e3dd41e5b267fb444feb4d3f6a2a6031227af8cadfa4ad0"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
-  pruneopts = ""
   revision = "13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272"
 
 [[projects]]
-  digest = "1:2d7624c60176d2eefb4d5029163002282de792172273cd965d8d3ce2dfcd1ccf"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  pruneopts = ""
   revision = "6aced65f8501fe1217321abf0749d354824ba2ff"
 
 [[projects]]
-  digest = "1:60a4d50770b16e62199e9acad6bc92b6835d93538545933d48fc7adf0f4d8edb"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  pruneopts = ""
   revision = "1d0bd113de87027671077d3c71eb3ac5d7dbba72"
 
 [[projects]]
-  digest = "1:ffb5b7428f6b19409284b9b6907878190189c14e48b4e83aaa591e3a921d6429"
   name = "github.com/gogo/protobuf"
-  packages = [
-    "proto",
-    "sortkeys",
-  ]
-  pruneopts = ""
+  packages = ["proto","sortkeys"]
   revision = "e18d7aa8f8c624c915db340349aad4c49b10d173"
 
 [[projects]]
-  digest = "1:ed314700d20eeaaa904b47e6fd3d4866f7bd14887a4904a9f69ec1e47385416f"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = ""
   revision = "44145f04b68cf362d9c4df2182967c2275eaefed"
 
 [[projects]]
-  digest = "1:515a069bab37826c425e12345063ae6a0cc711121819e1eeaab1da4052d72dbf"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
-  pruneopts = ""
   revision = "02826c3e79038b59d737d3b1c0a1d937f71a4433"
 
 [[projects]]
-  digest = "1:617ff1d7c2ba3ba08f0c4cde79ff569324e972c3dbba3d42ed07f9649595c520"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  pruneopts = ""
   revision = "8616e8ee5e20a1704615e6c8d7afcdac06087a67"
 
 [[projects]]
-  digest = "1:a2823c34933d4a2b36284f617f483d51fe156a443923284b3660f183dcfa3338"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  pruneopts = ""
   revision = "44d81051d367757e1c7c6a5a86423ece9afcf63c"
 
 [[projects]]
-  digest = "1:a4684067c99516927192da7fece2190f2ec1aebc5709d89392f910ae3921d18c"
   name = "github.com/hashicorp/hcl"
-  packages = [
-    ".",
-    "hcl/ast",
-    "hcl/parser",
-    "hcl/scanner",
-    "hcl/strconv",
-    "hcl/token",
-    "json/parser",
-    "json/scanner",
-    "json/token",
-  ]
-  pruneopts = ""
+  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
   revision = "d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1"
 
 [[projects]]
-  digest = "1:57925cae2350c91dadfadf9d4e28bc076c9be5ffd87213db314805a8d38aba26"
   name = "github.com/howeyc/gopass"
   packages = ["."]
-  pruneopts = ""
   revision = "3ca23474a7c7203e0a0a070fd33508f6efdb9b3d"
 
 [[projects]]
-  digest = "1:af7e132906cb360f4d7c34a9e1434825467f21c4ff5c521ad4cc5b55352876a8"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  pruneopts = ""
   revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"
 
 [[projects]]
-  digest = "1:2b282bd76718cf2443ea6c5143d0915840ed15417c970619f7e08674de5f4eea"
   name = "github.com/juju/ratelimit"
   packages = ["."]
-  pruneopts = ""
   revision = "77ed1c8a01217656d2080ad51981f6e99adaa177"
 
 [[projects]]
   branch = "master"
-  digest = "1:abde445510ed7b23086372c0bfdb607091e8118ca94ee853153a2d7709d65087"
   name = "github.com/kr/fs"
   packages = ["."]
-  pruneopts = ""
   revision = "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
 
 [[projects]]
-  digest = "1:d73babf15d484ad1ea56c8402df06ca68d4a3ade03f845701a86a86edfab7ad1"
   name = "github.com/kubernetes-incubator/external-storage"
-  packages = [
-    "lib/controller",
-    "lib/leaderelection",
-    "lib/leaderelection/resourcelock",
-  ]
-  pruneopts = ""
+  packages = ["lib/controller","lib/leaderelection","lib/leaderelection/resourcelock"]
   revision = "11dd9d7b2915b8c39147db492fe9d00562955318"
   version = "v2.1.0"
 
 [[projects]]
-  digest = "1:f2dfc1a0b89affe26feaff956a955aef5b13fb58ad3dd82fb773bf0afa940a92"
   name = "github.com/magiconair/properties"
   packages = ["."]
-  pruneopts = ""
   revision = "0723e352fa358f9322c938cc2dadda874e9151a9"
 
 [[projects]]
-  digest = "1:5f3c38b5f2dd7bec9286e00c3ac7babbe68859cc0edc4d3e3ba3fda93c24d7e7"
   name = "github.com/mailru/easyjson"
-  packages = [
-    "buffer",
-    "jlexer",
-    "jwriter",
-  ]
-  pruneopts = ""
+  packages = ["buffer","jlexer","jwriter"]
   revision = "d5b7844b561a7bc640052f1b935f7b800330d7e0"
 
 [[projects]]
-  digest = "1:5cede773920242d962f02e2adc7596b23f7acc5f8ea93714a3f8a934579ffaa1"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  pruneopts = ""
   revision = "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
 
 [[projects]]
-  digest = "1:a8f808f13da8f202c83ab5e754fb644cae251f24c90a67b36dfcc67d165f9005"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  pruneopts = ""
   revision = "db1efb556f84b25a0a13a04aad883943538ad2e0"
 
 [[projects]]
-  digest = "1:3e6edf30061fbdbb55f0e99a78891cad4c4cb0307bdbb42f5f02813c431c2fcc"
   name = "github.com/pborman/uuid"
   packages = ["."]
-  pruneopts = ""
   revision = "ca53cad383cad2479bbba7f7a1a05797ec1386e4"
 
 [[projects]]
-  digest = "1:4695c53c1975d06fdfc3e72b900d7cce9c7b8a402d32e636d142090a5285af4d"
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
-  pruneopts = ""
   revision = "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d"
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:d36e8abec0c59acac37eb3ad8fa7e96c0983bd808a30a45e5d77e517f92f5608"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  pruneopts = ""
   revision = "45932ad32dfdd20826f5671da37a5f3ce9f26a8d"
 
 [[projects]]
-  digest = "1:9a88d02723adf65f195ffec4bb458024113027188015555f30e2743d9f006b11"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = ""
   revision = "a22138067af1c4942683050411a841ade67fe1eb"
 
 [[projects]]
-  digest = "1:15dea2b42d9b823f300e3fcdddb00dc60ddd5556f511eb4adc415d94c4335d38"
   name = "github.com/pkg/sftp"
   packages = ["."]
-  pruneopts = ""
   revision = "4d0e916071f68db74f8a73926335f809396d6b42"
 
 [[projects]]
-  digest = "1:31ba63a60f9e41b5cbb6cce48f4756718bd514fe73a1c6ee2751ec8fbf6e109f"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = ""
   revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
 
 [[projects]]
-  digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
   name = "github.com/prometheus/client_golang"
-  packages = [
-    "prometheus",
-    "prometheus/promhttp",
-  ]
-  pruneopts = ""
+  packages = ["prometheus","prometheus/promhttp"]
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:d20fc05e7dfd1cf72429188a04109e12937ff582b9f9e3a700b2665349b7ca95"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  pruneopts = ""
   revision = "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
 
 [[projects]]
-  digest = "1:36bc45062264b0b716f9eff11a9d07328ed9e2cf2a97e9f7473641733e6294a1"
   name = "github.com/prometheus/common"
-  packages = [
-    "expfmt",
-    "model",
-  ]
-  pruneopts = ""
+  packages = ["expfmt","model"]
   revision = "ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650"
 
 [[projects]]
-  digest = "1:396f7d7a0e23f62df4dbcda921c74a74e7d25b2fea7e81759fc58d5967d514df"
   name = "github.com/prometheus/procfs"
   packages = ["."]
-  pruneopts = ""
   revision = "fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60"
 
 [[projects]]
   branch = "master"
-  digest = "1:daf7ece9411f44f7a6f1ef6ee7e8f8e3a5fa45c3f75d1c631210790537ba24c7"
   name = "github.com/simt2/go-zfs"
   packages = ["."]
-  pruneopts = ""
   revision = "1716e0f6768bfdedb714a35e56b78c479d8080fa"
 
 [[projects]]
-  digest = "1:a3b50b16dd7ab896dfc78d739e8aa1da415768424d111bcdbca14aef8cb3f04c"
   name = "github.com/spf13/afero"
-  packages = [
-    ".",
-    "mem",
-    "sftp",
-  ]
-  pruneopts = ""
+  packages = [".","mem","sftp"]
   revision = "b28a7effac979219c2a2ed6205a4d70e4b1bcd02"
 
 [[projects]]
-  digest = "1:e1daa2c9d617f8e63d9c28820a4b48546430549ff4540f57e3415789259f2316"
   name = "github.com/spf13/cast"
   packages = ["."]
-  pruneopts = ""
   revision = "2580bc98dc0e62908119e4737030cc2fdfc45e4c"
 
 [[projects]]
-  digest = "1:f0116a3f4f5b36e3917f7758c67a80488606288f87e716e88f11b845200cc003"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  pruneopts = ""
   revision = "33c24e77fb80341fe7130ee7c594256ff08ccc46"
 
 [[projects]]
-  digest = "1:3d93c7c561ca745667a66a9d85654d8d5f87bdbbcf71e85a8996d3210d9dafde"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = ""
   revision = "dabebe21bf790f782ea4c7bbd2efc430de182afd"
 
 [[projects]]
-  digest = "1:e7b08983bb661c7d7c6b1ea5cf026b1ff373d6cffb8a40dd9b57aa8fc7468a9f"
   name = "github.com/spf13/viper"
   packages = ["."]
-  pruneopts = ""
   revision = "50515b700e02658272117a72bd641b6b7f1222e5"
 
 [[projects]]
-  digest = "1:3926a4ec9a4ff1a072458451aa2d9b98acd059a45b38f7335d31e06c3d6a0159"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  pruneopts = ""
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [[projects]]
-  digest = "1:cb2800cd5716e9d6172888e0e3ffe1f9c07b7f142eb83d49a391029bcf4f6cc1"
   name = "github.com/ugorji/go"
   packages = ["codec"]
-  pruneopts = ""
   revision = "ded73eae5db7e7a0ef6f55aace87a2873c5d2b74"
 
 [[projects]]
-  digest = "1:0f67b4bbcdf1caaee0450f225a53fd2c2f8793578cc7810eb09c290e008e33ac"
   name = "golang.org/x/crypto"
-  packages = [
-    "curve25519",
-    "ed25519",
-    "ed25519/internal/edwards25519",
-    "ssh",
-    "ssh/terminal",
-  ]
-  pruneopts = ""
+  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/terminal"]
   revision = "d172538b2cfce0c13cee31e647d0367aa8cd2486"
 
 [[projects]]
-  digest = "1:8d5d4c9d4b35fe2abfc82ec0bb371d50ac9aef414f09ad756f5dff54dd81df94"
   name = "golang.org/x/net"
-  packages = [
-    "http2",
-    "http2/hpack",
-    "idna",
-    "lex/httplex",
-  ]
-  pruneopts = ""
+  packages = ["http2","http2/hpack","idna","lex/httplex"]
   revision = "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
 
 [[projects]]
-  digest = "1:b6e4bf8197b5de25f2ed05c603d39d619f4c41bb4a573ef5274c3446df44d6e4"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  pruneopts = ""
   revision = "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9"
 
 [[projects]]
-  digest = "1:9fa38bfa647dffc304504ea076b54f7eeb28f7ff7476536695abffcc1addd6d1"
   name = "golang.org/x/text"
-  packages = [
-    "cases",
-    "internal/gen",
-    "internal/tag",
-    "internal/triegen",
-    "internal/ucd",
-    "language",
-    "runes",
-    "secure/bidirule",
-    "secure/precis",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable",
-    "width",
-  ]
-  pruneopts = ""
+  packages = ["cases","internal/gen","internal/tag","internal/triegen","internal/ucd","language","runes","secure/bidirule","secure/precis","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
   revision = "2910a502d2bf9e43193af9d68ca516529614eed3"
 
 [[projects]]
-  digest = "1:e5d1fb981765b6f7513f793a3fcaac7158408cca77f75f7311ac82cc88e9c445"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  pruneopts = ""
   revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
   version = "v0.9.0"
 
 [[projects]]
-  digest = "1:0763e9b61d1ce4cc56451110312698daadb7273385c7425c746f06ae7d68e3f3"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = ""
   revision = "a5b47d31c556af34a302ce5d659e6fea44d90de0"
 
 [[projects]]
-  digest = "1:772a730aa78a94b302c43f6a86f7178838bff8c4a225328de3743d66a4e56cc9"
   name = "k8s.io/apimachinery"
-  packages = [
-    "pkg/api/errors",
-    "pkg/api/meta",
-    "pkg/api/resource",
-    "pkg/apimachinery",
-    "pkg/apimachinery/announced",
-    "pkg/apimachinery/registered",
-    "pkg/apis/meta/v1",
-    "pkg/apis/meta/v1/unstructured",
-    "pkg/conversion",
-    "pkg/conversion/queryparams",
-    "pkg/fields",
-    "pkg/labels",
-    "pkg/openapi",
-    "pkg/runtime",
-    "pkg/runtime/schema",
-    "pkg/runtime/serializer",
-    "pkg/runtime/serializer/json",
-    "pkg/runtime/serializer/protobuf",
-    "pkg/runtime/serializer/recognizer",
-    "pkg/runtime/serializer/streaming",
-    "pkg/runtime/serializer/versioning",
-    "pkg/selection",
-    "pkg/types",
-    "pkg/util/diff",
-    "pkg/util/errors",
-    "pkg/util/framer",
-    "pkg/util/intstr",
-    "pkg/util/json",
-    "pkg/util/mergepatch",
-    "pkg/util/net",
-    "pkg/util/rand",
-    "pkg/util/runtime",
-    "pkg/util/sets",
-    "pkg/util/strategicpatch",
-    "pkg/util/uuid",
-    "pkg/util/validation",
-    "pkg/util/validation/field",
-    "pkg/util/wait",
-    "pkg/util/yaml",
-    "pkg/version",
-    "pkg/watch",
-    "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect",
-  ]
-  pruneopts = ""
+  packages = ["pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apimachinery","pkg/apimachinery/announced","pkg/apimachinery/registered","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/openapi","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/mergepatch","pkg/util/net","pkg/util/rand","pkg/util/runtime","pkg/util/sets","pkg/util/strategicpatch","pkg/util/uuid","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/json","third_party/forked/golang/reflect"]
   revision = "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
 
 [[projects]]
-  digest = "1:ddaf109a69f97a91d93108434136fc6e30603ece0e49d6d22aae6befbe2632e3"
   name = "k8s.io/client-go"
-  packages = [
-    "discovery",
-    "kubernetes",
-    "kubernetes/scheme",
-    "kubernetes/typed/apps/v1beta1",
-    "kubernetes/typed/authentication/v1",
-    "kubernetes/typed/authentication/v1beta1",
-    "kubernetes/typed/authorization/v1",
-    "kubernetes/typed/authorization/v1beta1",
-    "kubernetes/typed/autoscaling/v1",
-    "kubernetes/typed/autoscaling/v2alpha1",
-    "kubernetes/typed/batch/v1",
-    "kubernetes/typed/batch/v2alpha1",
-    "kubernetes/typed/certificates/v1beta1",
-    "kubernetes/typed/core/v1",
-    "kubernetes/typed/extensions/v1beta1",
-    "kubernetes/typed/policy/v1beta1",
-    "kubernetes/typed/rbac/v1alpha1",
-    "kubernetes/typed/rbac/v1beta1",
-    "kubernetes/typed/settings/v1alpha1",
-    "kubernetes/typed/storage/v1",
-    "kubernetes/typed/storage/v1beta1",
-    "pkg/api",
-    "pkg/api/install",
-    "pkg/api/v1",
-    "pkg/apis/apps",
-    "pkg/apis/apps/install",
-    "pkg/apis/apps/v1beta1",
-    "pkg/apis/authentication",
-    "pkg/apis/authentication/install",
-    "pkg/apis/authentication/v1",
-    "pkg/apis/authentication/v1beta1",
-    "pkg/apis/authorization",
-    "pkg/apis/authorization/install",
-    "pkg/apis/authorization/v1",
-    "pkg/apis/authorization/v1beta1",
-    "pkg/apis/autoscaling",
-    "pkg/apis/autoscaling/install",
-    "pkg/apis/autoscaling/v1",
-    "pkg/apis/autoscaling/v2alpha1",
-    "pkg/apis/batch",
-    "pkg/apis/batch/install",
-    "pkg/apis/batch/v1",
-    "pkg/apis/batch/v2alpha1",
-    "pkg/apis/certificates",
-    "pkg/apis/certificates/install",
-    "pkg/apis/certificates/v1beta1",
-    "pkg/apis/extensions",
-    "pkg/apis/extensions/install",
-    "pkg/apis/extensions/v1beta1",
-    "pkg/apis/policy",
-    "pkg/apis/policy/install",
-    "pkg/apis/policy/v1beta1",
-    "pkg/apis/rbac",
-    "pkg/apis/rbac/install",
-    "pkg/apis/rbac/v1alpha1",
-    "pkg/apis/rbac/v1beta1",
-    "pkg/apis/settings",
-    "pkg/apis/settings/install",
-    "pkg/apis/settings/v1alpha1",
-    "pkg/apis/storage",
-    "pkg/apis/storage/install",
-    "pkg/apis/storage/v1",
-    "pkg/apis/storage/v1beta1",
-    "pkg/util",
-    "pkg/util/parsers",
-    "pkg/version",
-    "rest",
-    "rest/watch",
-    "tools/auth",
-    "tools/cache",
-    "tools/clientcmd",
-    "tools/clientcmd/api",
-    "tools/clientcmd/api/latest",
-    "tools/clientcmd/api/v1",
-    "tools/metrics",
-    "tools/record",
-    "transport",
-    "util/cert",
-    "util/clock",
-    "util/flowcontrol",
-    "util/homedir",
-    "util/integer",
-  ]
-  pruneopts = ""
+  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/apps/v1beta1","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/api","pkg/api/install","pkg/api/v1","pkg/apis/apps","pkg/apis/apps/install","pkg/apis/apps/v1beta1","pkg/apis/authentication","pkg/apis/authentication/install","pkg/apis/authentication/v1","pkg/apis/authentication/v1beta1","pkg/apis/authorization","pkg/apis/authorization/install","pkg/apis/authorization/v1","pkg/apis/authorization/v1beta1","pkg/apis/autoscaling","pkg/apis/autoscaling/install","pkg/apis/autoscaling/v1","pkg/apis/autoscaling/v2alpha1","pkg/apis/batch","pkg/apis/batch/install","pkg/apis/batch/v1","pkg/apis/batch/v2alpha1","pkg/apis/certificates","pkg/apis/certificates/install","pkg/apis/certificates/v1beta1","pkg/apis/extensions","pkg/apis/extensions/install","pkg/apis/extensions/v1beta1","pkg/apis/policy","pkg/apis/policy/install","pkg/apis/policy/v1beta1","pkg/apis/rbac","pkg/apis/rbac/install","pkg/apis/rbac/v1alpha1","pkg/apis/rbac/v1beta1","pkg/apis/settings","pkg/apis/settings/install","pkg/apis/settings/v1alpha1","pkg/apis/storage","pkg/apis/storage/install","pkg/apis/storage/v1","pkg/apis/storage/v1beta1","pkg/util","pkg/util/parsers","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/record","transport","util/cert","util/clock","util/flowcontrol","util/homedir","util/integer"]
   revision = "76153773eaa3a268131d3d993290a194a1370585"
 
 [[projects]]
-  digest = "1:19b9e843c2efa09c7b7b3ba535ae843bd7b5f8e52a75d6a914798df1f8d19782"
   name = "k8s.io/kubernetes"
-  packages = [
-    "pkg/util/goroutinemap",
-    "pkg/util/goroutinemap/exponentialbackoff",
-    "pkg/util/version",
-  ]
-  pruneopts = ""
+  packages = ["pkg/util/goroutinemap","pkg/util/goroutinemap/exponentialbackoff","pkg/util/version"]
   revision = "fff5156092b56e6bd60fff75aad4dc9de6b6ef37"
   version = "v1.6.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/Sirupsen/logrus",
-    "github.com/gentics/kubernetes-zfs-provisioner/pkg/provisioner",
-    "github.com/kubernetes-incubator/external-storage/lib/controller",
-    "github.com/prometheus/client_golang/prometheus",
-    "github.com/prometheus/client_golang/prometheus/promhttp",
-    "github.com/simt2/go-zfs",
-    "github.com/spf13/viper",
-    "github.com/stretchr/testify/assert",
-    "k8s.io/apimachinery/pkg/api/resource",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/util/validation",
-    "k8s.io/apimachinery/pkg/util/validation/field",
-    "k8s.io/apimachinery/pkg/util/wait",
-    "k8s.io/client-go/kubernetes",
-    "k8s.io/client-go/pkg/api/v1",
-    "k8s.io/client-go/tools/clientcmd",
-  ]
+  inputs-digest = "8c89b6ca01f41542de5cf533925ef76ca35d7d4c16b78765b57e08c8ffa9a1a0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/zfs-provisioner/main.go
+++ b/cmd/zfs-provisioner/main.go
@@ -64,7 +64,7 @@ func main() {
 		"config": viper.GetString("kube_conf"),
 	}).Info("Loaded kubernetes config")
 
-	log.Info("Found export directive: ", viper.GetBool("enable_export"))
+	log.Debug("Found export directive: ", viper.GetBool("enable_export"))
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/cmd/zfs-provisioner/main.go
+++ b/cmd/zfs-provisioner/main.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/gentics/kubernetes-zfs-provisioner/pkg/provisioner"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -19,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"kubernetes-zfs-provisioner/pkg/provisioner"
 )
 
 const (
@@ -40,6 +40,7 @@ func main() {
 	viper.SetDefault("provisioner_name", "gentics.com/zfs")
 	viper.SetDefault("metrics_port", "8080")
 	viper.SetDefault("debug", false)
+	viper.SetDefault("enable_export", true)
 
 	if viper.GetBool("debug") == true {
 		log.SetLevel(log.DebugLevel)
@@ -62,6 +63,8 @@ func main() {
 	log.WithFields(log.Fields{
 		"config": viper.GetString("kube_conf"),
 	}).Info("Loaded kubernetes config")
+
+	log.Info("Found export directive: ", viper.GetBool("enable_export"))
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -105,7 +108,7 @@ func main() {
 	}
 
 	// Create the provisioner
-	zfsProvisioner := provisioner.NewZFSProvisioner(parent, viper.GetString("share_options"), viper.GetString("server_hostname"), viper.GetString("kube_reclaim_policy"))
+	zfsProvisioner := provisioner.NewZFSProvisioner(parent, viper.GetString("share_options"), viper.GetString("server_hostname"), viper.GetString("kube_reclaim_policy"), viper.GetBool("enable_export"))
 
 	// Start and export the prometheus collector
 	registry := prometheus.NewPedanticRegistry()

--- a/pkg/provisioner/delete.go
+++ b/pkg/provisioner/delete.go
@@ -16,9 +16,15 @@ func (p ZFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 		return err
 	}
 
-	log.WithFields(log.Fields{
-		"volume": volume.Spec.NFS.Path,
-	}).Info("Deleted volume")
+	if p.exportNfs {
+		log.WithFields(log.Fields{
+			"volume": volume.Spec.NFS.Path,
+		}).Info("Deleted volume")
+	} else {
+		log.WithFields(log.Fields{
+			"volume": volume.Spec.HostPath.Path,
+		}).Info("Deleted volume")
+	}
 	return nil
 }
 

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -84,11 +84,10 @@ func (p ZFSProvisioner) createVolume(options controller.VolumeOptions) (string, 
 
 	if p.exportNfs {
 		log.Info("Enabling NFS export with options: ", p.shareOptions)
-		properties["sharenfs"] = p.shareOptions
 	} else {
 		log.Info("Disabling NFS export")
-		properties["sharenfs"] = "off"
 	}
+	properties["sharenfs"] = p.shareOptions
 
 	storageRequest := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	storageRequestBytes := strconv.FormatInt(storageRequest.Value(), 10)

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -25,27 +25,52 @@ func (p ZFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Persist
 	annotations := make(map[string]string)
 	annotations[annCreatedBy] = createdBy
 
-	pv := &v1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        options.PVName,
-			Labels:      map[string]string{},
-			Annotations: annotations,
-		},
-		Spec: v1.PersistentVolumeSpec{
-			PersistentVolumeReclaimPolicy: p.reclaimPolicy,
-			AccessModes:                   options.PVC.Spec.AccessModes,
-			Capacity: v1.ResourceList{
-				v1.ResourceName(v1.ResourceStorage): options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
+	var pv *v1.PersistentVolume
+
+	if p.exportNfs {
+		pv = &v1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        options.PVName,
+				Labels:      map[string]string{},
+				Annotations: annotations,
 			},
-			PersistentVolumeSource: v1.PersistentVolumeSource{
-				NFS: &v1.NFSVolumeSource{
-					Server:   p.serverHostname,
-					Path:     path,
-					ReadOnly: false,
+			Spec: v1.PersistentVolumeSpec{
+				PersistentVolumeReclaimPolicy: p.reclaimPolicy,
+				AccessModes:                   options.PVC.Spec.AccessModes,
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
+				},
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					NFS: &v1.NFSVolumeSource{
+						Server:   p.serverHostname,
+						Path:     path,
+						ReadOnly: false,
+					},
 				},
 			},
-		},
+		}
+	} else {
+		pv = &v1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        options.PVName,
+				Labels:      map[string]string{},
+				Annotations: annotations,
+			},
+			Spec: v1.PersistentVolumeSpec{
+				PersistentVolumeReclaimPolicy: p.reclaimPolicy,
+				AccessModes:                   options.PVC.Spec.AccessModes,
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
+				},
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: path,
+					},
+				},
+			},
+		}
 	}
+
 	log.Debug("Returning pv:")
 	log.Debug(*pv)
 
@@ -57,7 +82,13 @@ func (p ZFSProvisioner) createVolume(options controller.VolumeOptions) (string, 
 	zfsPath := p.parent.Name + "/" + options.PVName
 	properties := make(map[string]string)
 
-	properties["sharenfs"] = p.shareOptions
+	if p.exportNfs {
+		log.Info("Enabling NFS export with options: ", p.shareOptions)
+		properties["sharenfs"] = p.shareOptions
+	} else {
+		log.Info("Disabling NFS export")
+		properties["sharenfs"] = "off"
+	}
 
 	storageRequest := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	storageRequestBytes := strconv.FormatInt(storageRequest.Value(), 10)

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -16,6 +16,7 @@ const (
 type ZFSProvisioner struct {
 	parent *zfs.Dataset // The parent dataset
 
+	exportNfs      bool   // true we should export the nfs share, false we should not
 	shareOptions   string // Additional nfs export options, comma-separated
 	serverHostname string // The hostname that should be returned as NFS Server
 	reclaimPolicy  v1.PersistentVolumeReclaimPolicy
@@ -58,7 +59,7 @@ func (p ZFSProvisioner) Collect(ch chan<- prometheus.Metric) {
 }
 
 // NewZFSProvisioner returns a new ZFSProvisioner
-func NewZFSProvisioner(parent *zfs.Dataset, shareOptions string, serverHostname string, reclaimPolicy string) ZFSProvisioner {
+func NewZFSProvisioner(parent *zfs.Dataset, shareOptions string, serverHostname string, reclaimPolicy string, doNfsExport bool) ZFSProvisioner {
 	var kubernetesReclaimPolicy v1.PersistentVolumeReclaimPolicy
 	// Parse reclaim policy
 	switch reclaimPolicy {
@@ -68,9 +69,14 @@ func NewZFSProvisioner(parent *zfs.Dataset, shareOptions string, serverHostname 
 		kubernetesReclaimPolicy = v1.PersistentVolumeReclaimRetain
 	}
 
+	if doNfsExport {
+		shareOptions = "off"
+	}
+
 	return ZFSProvisioner{
 		parent: parent,
 
+		exportNfs:      doNfsExport,
 		shareOptions:   shareOptions,
 		serverHostname: serverHostname,
 		reclaimPolicy:  kubernetesReclaimPolicy,

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -69,7 +69,7 @@ func NewZFSProvisioner(parent *zfs.Dataset, shareOptions string, serverHostname 
 		kubernetesReclaimPolicy = v1.PersistentVolumeReclaimRetain
 	}
 
-	if doNfsExport {
+	if !doNfsExport {
 		shareOptions = "off"
 	}
 


### PR DESCRIPTION
This allows nodes to create local only zfs filesystems that are mounted into a pod via a hostPath persistent volume. This is useful if applications are deployed in kubernetes via statefulSets (for example zookeeper or cassandra) and the cluster administrator wants to automatically provision the persistent storage from a given zpool.