### PR TITLE
Allow docker deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ bin
 .DS_Store
 .env
 kube.conf
+
+#Intellij
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+MAINTAINER Rajha Korithrien <rajha.korithrien@gmail.com>
+
+#This docker file is useful for creating a docker container that is used on a system where
+#The host provides the zfs binary via a volume/bind mount.
+#We don't package a zfs binary in this image so the host can ensure it provides a userland binary that matches the
+#kernel module.
+
+#This container must be run with privlege, and have access to the hosts /dev/zfs device
+COPY /bin/zfs-provisioner /zfs-provisioner
+ENTRYPOINT ["/zfs-provisioner"]

--- a/Dockerfile.rancher
+++ b/Dockerfile.rancher
@@ -1,0 +1,17 @@
+FROM alpine:latest
+MAINTAINER Rajha Korithrien <rajha.korithrien@gmail.com>
+
+# This Dockerfile is used to build a container that can be deployed as a custom service on RancherOS
+# Refer to deploy/rancher/README.md for more details.
+
+COPY /bin/zfs-provisioner /zfs-provisioner
+COPY deploy/rancher/provisioner-entry.sh /provisioner-entry.sh
+
+RUN chmod +x /zfs-provisioner
+RUN chmod +x /provisioner-entry.sh
+
+RUN mkdir -p /usr/sbin
+COPY deploy/rancher/zfs /usr/sbin/zfs
+RUN chmod +x /usr/sbin/zfs
+
+ENTRYPOINT ["/provisioner-entry.sh", "/zfs-provisioner"]

--- a/deploy/rancher/README.md
+++ b/deploy/rancher/README.md
@@ -16,6 +16,17 @@ zfs-tools container
 we can get at the system-docker command, and that we bindmount /host/dev to /dev. This means that our service needs to be
 given a copy of the host /dev tree initially as /host/dev
 
+## Building
+Use the instructions provided in the overall repo for building the GO based zfs-provisioner binary. You can then create
+the RancherOS docker image by doing the following from the root of the repo.
+```bash
+docker build -t rajhakorithrien/rancher-zfs-provisioner -f Dockerfile.rancher .
+docker push rajhakorithrien/rancher-zfs-provisioner:latest
+```
+Of course you will want to change your image name and version to suite your deployment environment. These instructions
+assume deployment to a pre-existing Dockerhub image repo that you will most likely not have push access to. Feel free to
+pull this image, but as it must run with privilege, we suggest building your own.
+
 ## Deploy to RancherOS
 RancherOS provides a mechanism to deploy custom system services via a docker-compose file. We use this docker-compose
 file to setup the environment for zfs-provisioner. We provide an example of such a docker-compose file which should be

--- a/deploy/rancher/README.md
+++ b/deploy/rancher/README.md
@@ -1,0 +1,24 @@
+# RancherOS Deployment
+RancherOS is a very small linux distro that makes everything into a docker container, including all of its system
+services. As such in order to correctly deploy zfs-provisioner to RancherOS as a system service the container must have
+access to both the /dev/zfs device and the zfs binary. This poses a problem as when zfs is installed on a RancherOS host
+the actual zfs binary (along with zpool) are installed inside a zfs-tools docker image/container. This container does
+not export any volumes that we can use so there is no direct way to get ahold of the zfs binary from within another
+docker container.
+
+## Workaround
+RancherOS when it installs its zfs service creates a shell script in the "console" container that wraps a call around
+the execution of the zfs-tools image. We do the same here, the idea being that we run zfs-provisioner as a custom
+RancherOS service inside its own container. The container is setup as follows:
+* deploy/rancher/zfs - is a shell script that calls the RancherOS 'system-docker' command which passes arguments to the
+zfs-tools container
+* provisioner-entry.sh - is a shell script that we use as the main entrypoint for our service. This script checks that
+we can get at the system-docker command, and that we bindmount /host/dev to /dev. This means that our service needs to be
+given a copy of the host /dev tree initially as /host/dev
+
+## Deploy to RancherOS
+RancherOS provides a mechanism to deploy custom system services via a docker-compose file. We use this docker-compose
+file to setup the environment for zfs-provisioner. We provide an example of such a docker-compose file which should be
+placed in /var/lib/rancher/conf as its own file, or put into a cloud-config.yml file.
+See [the RancherOS custom services documentation](https://rancher.com/docs/os/v1.2/en/system-services/custom-system-services/)
+for more details. 

--- a/deploy/rancher/example-provisioner.yaml
+++ b/deploy/rancher/example-provisioner.yaml
@@ -1,0 +1,22 @@
+zfs-provisioner:
+  image: rajhakorithrien/rancher-zfs-provisioner:latest
+  restart: always
+  net: host
+  pid: host
+  uts: host
+  ipc: host
+  privileged: true
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: "zfs"
+  volumes:
+    - /dev:/host/dev
+  volumes_from:
+    - all-volumes
+  environment:
+    - PATH=/bin:/sbin:/usr/sbin:/usr/bin
+    - ZFS_ENABLE_EXPORT=true
+    - ZFS_DEBUG=false
+    - ZFS_PARENT_DATASET=kubernetes-mirror/pvc
+    - ZFS_PROVISIONER_NAME=gentics.com/zfs-mirror-a
+    - ZFS_KUBE_CONF=/home/rancher/kube_config_rancher-cluster.yml

--- a/deploy/rancher/provisioner-entry.sh
+++ b/deploy/rancher/provisioner-entry.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#Check that we are on Rancher and can use ros
+if [ ! -e /usr/bin/system-docker ]; then
+    echo "This image can only be used on RancherOS when it has access to system-docker."
+    exit 1
+fi
+
+#Make our device tree be in the correct place
+mount --rbind /host/dev /dev > /dev/null 2>&1
+
+#Now we execute the zfs-provisioner
+echo "Starting zfs-provisioner via $@"
+echo "Naming zfs-provisioner: $ZFS_PROVISIONER_NAME"
+exec "$@"

--- a/deploy/rancher/provisioner-entry.sh
+++ b/deploy/rancher/provisioner-entry.sh
@@ -11,5 +11,5 @@ mount --rbind /host/dev /dev > /dev/null 2>&1
 
 #Now we execute the zfs-provisioner
 echo "Starting zfs-provisioner via $@"
-echo "Naming zfs-provisioner: $ZFS_PROVISIONER_NAME"
+echo "Providing input name: $ZFS_PROVISIONER_NAME"
 exec "$@"

--- a/deploy/rancher/zfs
+++ b/deploy/rancher/zfs
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+exec /usr/bin/system-docker run --rm --privileged \
+                --pid host \
+                --net host \
+                --ipc host \
+		-v /mnt:/mnt:shared \
+		-v /media:/media:shared \
+		-v /dev:/host/dev \
+		-v /run:/run \
+		zfs-tools $(basename $0) "$@"


### PR DESCRIPTION
This is used to be able to deploy the provisioner via a container rather than having to install it on the host system. This is useful when wanting to use a container orchestration system to deploy this provisioner